### PR TITLE
fix http method for `awsAccountRole`

### DIFF
--- a/src/alks.js
+++ b/src/alks.js
@@ -327,7 +327,7 @@ class alks {
     * })
     */
   awsAccountRoles(props) {
-    return(this._doFetch('awsAccountRoles', props).then(results => results.awsRoleList))
+    return(this._doFetch('awsAccountRoles', props, 'GET').then(results => results.awsRoleList))
   }
 
   /**

--- a/src/alks.js
+++ b/src/alks.js
@@ -327,7 +327,7 @@ class alks {
     * })
     */
   awsAccountRoles(props) {
-    return(this._doFetch('awsAccountRoles', props, 'GET').then(results => results.awsRoleList))
+    return(this._doFetch(`awsAccountRoles?account=${props.account}`, props, 'GET').then(results => results.awsRoleList))
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -253,7 +253,7 @@ describe('alks.js', function() {
       ]
 
       const _fetch = fetchMock.sandbox().mock('https://your.alks-host.com/allAwsRoleTypes/', {
-        body: { 
+        body: {
           statusMessage: 'Success',
           requestId: 'reqId',
           roleTypes: roleTypes
@@ -423,43 +423,43 @@ describe('alks.js', function() {
   describe('awsAccountRoles', () => {
 
     it('should return a list of roles', async () => {
-      const awsRoleList = JSON.parse(`[
-            {
-              "roleArn": "arn:aws:iam::805619180788:role/acct-managed/MyCustomRole1",
-              "isMachineIdentity": false,
-              "assumeRolePolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Action": "sts:AssumeRole",
-                    "Effect": "Allow",
-                    "Principal": {
-                      "Service": "s3.amazonaws.com"
-                    }
-                  }
-                ]
+      const awsRoleList = [
+        {
+          'roleArn': 'arn:aws:iam::805619180788:role/acct-managed/MyCustomRole1',
+          'isMachineIdentity': false,
+          'assumeRolePolicyDocument': {
+            'Version': '2012-10-17',
+            'Statement': [
+              {
+                'Action': 'sts:AssumeRole',
+                'Effect': 'Allow',
+                'Principal': {
+                  'Service': 's3.amazonaws.com'
+                }
               }
-            },
-            {
-              "roleArn": "arn:aws:iam::805619180788:role/acct-managed/MyCustomRole2",
-              "isMachineIdentity": true,
-              "assumeRolePolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Action": "sts:AssumeRole",
-                    "Effect": "Allow",
-                    "Principal": {
-                      "Service": "s3.amazonaws.com"
-                    }
-                  }
-                ]
+            ]
+          }
+        },
+        {
+          'roleArn': 'arn:aws:iam::805619180788:role/acct-managed/MyCustomRole2',
+          'isMachineIdentity': true,
+          'assumeRolePolicyDocument': {
+            'Version': '2012-10-17',
+            'Statement': [
+              {
+                'Action': 'sts:AssumeRole',
+                'Effect': 'Allow',
+                'Principal': {
+                  'Service': 's3.amazonaws.com'
+                }
               }
-            }
-          ]`)
+            ]
+          }
+        }
+      ]
 
-      const _fetch = fetchMock.sandbox().mock('https://your.alks-host.com/awsAccountRoles/', {
-        body: { 
+      const _fetch = fetchMock.sandbox().mock('https://your.alks-host.com/awsAccountRoles?account=1234567890/', {
+        body: {
           statusMessage: 'Success',
           requestId: 'reqId',
           awsRoleList: awsRoleList
@@ -470,7 +470,7 @@ describe('alks.js', function() {
       const result = await alks.awsAccountRoles({
         baseUrl: 'https://your.alks-host.com',
         accessToken: 'abc123',
-        account: '123457890',
+        account: '1234567890',
         _fetch
       })
 


### PR DESCRIPTION
changes the http method for the `/awsAccountRoles` endpoint to GET to be consistent with the ALKS Rest API