### PR TITLE
fixes Account type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare namespace ALKS {
     role: string;
     iamKeyActive: boolean;
     maxKeyDuration: number;
-    skypieaAccount: SkypieaAccount;
+    skypieaAccount: SkypieaAccount | null;
   }
 
   export interface SkypieaAccount {


### PR DESCRIPTION
accounts for the fact that SkypieaAccount is sometimes `null` for new accounts that haven't been configured yet