### PR TITLE
adds type definitions to included files for deployment in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "files": [
     "lib",
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Without this, the `index.d.ts` file containing type definitions doesn't get included when you `npm install` this package, so typescript isn't able to find it