### PR TITLE
STS Parameters not passed on HTTP GET requests #33

### DIFF
--- a/src/alks.js
+++ b/src/alks.js
@@ -773,7 +773,7 @@ class alks {
       delete opts.accessKey
     }
     if( opts.secretKey ) {
-      headers['ALKS-STS-Secret-Key'] = opts.secretKey;
+      headers['ALKS-STS-Secret-Key'] = opts.secretKey
       delete opts.secretKey
     }
     if( opts.sessionToken ) {

--- a/src/alks.js
+++ b/src/alks.js
@@ -768,6 +768,19 @@ class alks {
       delete opts.password
     }
 
+    if( opts.accessKey ) {
+      headers['ALKS-STS-Access-Key'] = opts.accessKey;
+      delete opts.accessKey
+    }
+    if( opts.secretKey ) {
+      headers['ALKS-STS-Secret-Key'] = opts.secretKey;
+      delete opts.secretKey
+    }
+    if( opts.sessionToken ) {
+      headers['ALKS-STS-Session-Token'] = opts.sessionToken;
+      delete opts.sessionToken
+    }
+
     var responsePromise = opts._fetch(`${opts.baseUrl}/${path}/`, {
       method, headers, body: method == 'GET' ? undefined : JSON.stringify(opts)
     })

--- a/src/alks.js
+++ b/src/alks.js
@@ -769,7 +769,7 @@ class alks {
     }
 
     if( opts.accessKey ) {
-      headers['ALKS-STS-Access-Key'] = opts.accessKey;
+      headers['ALKS-STS-Access-Key'] = opts.accessKey
       delete opts.accessKey
     }
     if( opts.secretKey ) {

--- a/src/alks.js
+++ b/src/alks.js
@@ -777,7 +777,7 @@ class alks {
       delete opts.secretKey
     }
     if( opts.sessionToken ) {
-      headers['ALKS-STS-Session-Token'] = opts.sessionToken;
+      headers['ALKS-STS-Session-Token'] = opts.sessionToken
       delete opts.sessionToken
     }
 


### PR DESCRIPTION
This passes STS credentials as headers instead of the body of the request. GET requests were failing with STS credentials and this resolves that issue.