### PR TITLE
Create npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,32 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+
+name: Alks.js Publish Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Creates yml file to configure Github action to publish npm package. The NPM token secret is stored in Github, go to Settings > Secrets to see it

One slight difference between this and how Travis used to publish is this triggers _when a new release is created_ instead of whenever a new tag is pushed. So now the flow is create new commit with package.json version bumped -> push up new tags to origin -> draft a release -> Github actions kicks off to deploy to NPM. If we don't like it this way we can change it to trigger on tag pushes so it will make the NPM release without needing a Github release, but I figured it is more convenient this way